### PR TITLE
Hyvä Checkout 1.3 strict-CSP compliance

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
       "magento/framework": "*",
       "checkoutcom/magento2": "^7.0.0",
       "hyva-themes/magento2-compat-module-fallback": "*",
-      "hyva-themes/magento2-hyva-checkout": "*"
+      "hyva-themes/magento2-hyva-checkout": "^1.3"
   },
   "license": "MIT",
   "autoload": {

--- a/etc/csp_whitelist.xml
+++ b/etc/csp_whitelist.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * @copyright Copyright (c) 2025 Magebit, Ltd. (https://magebit.com/)
+ * @author    Magebit <info@magebit.com>
+ * @license   MIT
+ */
+-->
+<csp_whitelist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Csp:etc/csp_whitelist.xsd">
+    <policies>
+        <policy id="script-src">
+            <values>
+                <value id="cko_cdn" type="host">https://cdn.checkout.com</value>
+                <value id="cko_checkout" type="host">https://*.checkout.com</value>
+                <value id="googlepay_js" type="host">https://pay.google.com</value>
+                <value id="googlepay_gstatic" type="host">https://*.gstatic.com</value>
+            </values>
+        </policy>
+        <policy id="connect-src">
+            <values>
+                <value id="cko_api" type="host">https://api.checkout.com</value>
+                <value id="cko_api_sandbox" type="host">https://api.sandbox.checkout.com</value>
+                <value id="cko_checkout" type="host">https://*.checkout.com</value>
+                <value id="googlepay" type="host">https://pay.google.com</value>
+            </values>
+        </policy>
+        <policy id="frame-src">
+            <values>
+                <value id="cko_checkout" type="host">https://*.checkout.com</value>
+                <value id="googlepay" type="host">https://pay.google.com</value>
+            </values>
+        </policy>
+        <policy id="img-src">
+            <values>
+                <value id="cko_checkout" type="host">https://*.checkout.com</value>
+            </values>
+        </policy>
+    </policies>
+</csp_whitelist>

--- a/view/frontend/templates/component/payment/method/apm/mbway.phtml
+++ b/view/frontend/templates/component/payment/method/apm/mbway.phtml
@@ -30,7 +30,8 @@ use Magento\Framework\View\Element\Template;
                            wire:model.delay.1000ms="mbwayCountryCode"
                            wire:loading.class="loading"
                            wire:loading.attr="disabled"
-                           oninput="this.value = this.value.replace(/[^0-9]/g, '')"
+                           inputmode="numeric"
+                           @input="stripNonDigits"
                            maxlength="3"
                     >
                 </div>
@@ -51,7 +52,8 @@ use Magento\Framework\View\Element\Template;
                            wire:model.delay.1000ms="mbwayPhoneNumber"
                            wire:loading.class="loading"
                            wire:loading.attr="disabled"
-                           oninput="this.value = this.value.replace(/[^0-9]/g, '')"
+                           inputmode="numeric"
+                           @input="stripNonDigits"
                            maxlength="9"
                     >
                 </div>

--- a/view/frontend/templates/scripts/apm.phtml
+++ b/view/frontend/templates/scripts/apm.phtml
@@ -61,6 +61,11 @@ use Magento\Framework\Escaper;
 
                 isMbWaySelected() {
                     return this.selectedMethod === 'mbway';
+                },
+
+                // CSP-safe replacement for inline oninput handlers (Hyvä Checkout 1.3 strict CSP)
+                stripNonDigits(event) {
+                    event.target.value = event.target.value.replace(/[^0-9]/g, '');
                 }
             };
         }


### PR DESCRIPTION
## What

Brings the module into compliance with **Hyvä Checkout 1.3+ strict CSP** (PCI-DSS 4.0 — no `unsafe-inline`/`unsafe-eval`, nonce-based scripts, Alpine CSP build).

### Changes
- **`mbway.phtml`** — the two MB WAY inputs used inline `oninput="..."` handlers, which are **blocked under strict CSP**. Replaced with a CSP-safe Alpine `@input="stripNonDigits"` (method reference) on the existing `checkoutComApm` component, plus `inputmode="numeric"`. Added a `stripNonDigits(event)` method to the component.
- **`etc/csp_whitelist.xml`** (new) — whitelists the external domains the module loads: Checkout.com Frames (`cdn.checkout.com`, `api(.sandbox).checkout.com`, `*.checkout.com` for 3DS frames), Google Pay (`pay.google.com`, `*.gstatic.com`) across `script-src`/`connect-src`/`frame-src`/`img-src`.
- **`composer.json`** — `hyva-themes/magento2-hyva-checkout` constraint `*` → `^1.3` to declare the tested baseline.

> Note: inline scripts in this module were already CSP-registered (`Alpine.data()` + `$hyvaCsp->registerInlineScript()`); the remaining gap was the mbway inline handlers + the missing whitelist.

## Testing
- [x] Static review against the Hyvä CSP idiom
- [ ] **Functional QA pending** — card/APM/Google Pay/Apple Pay flow + CSP console check on a Checkout.com sandbox (needs sandbox creds). The mbway change mirrors the module's existing CSP-safe Alpine pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)